### PR TITLE
Move off bitnamilegacy base; pin, harden, and slim the image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,23 +8,40 @@ on:
 env:
   IMAGE: ghcr.io/fino-digital/fluentd
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and Push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.ref_type == 'tag' }}
-          tags: ${{env.IMAGE}}:${{ github.ref_name }}
+          tags: ${{ env.IMAGE }}:${{ github.ref_name }}
+      # Report HIGH/CRITICAL vulns for visibility. Report-only for now
+      # (exit-code 0 + continue-on-error) so it never blocks a release; flip
+      # exit-code to 1 with --ignore-unfixed once the baseline is clean to gate
+      # on newly-introduced, fixable vulns.
+      - name: Trivy scan (report only)
+        if: ${{ github.ref_type == 'tag' }}
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE }}:${{ github.ref_name }}
+          format: table
+          severity: HIGH,CRITICAL
+          exit-code: "0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/bitnamilegacy/fluentd:1.17.1-debian-12-r6
+FROM docker.io/bitnamilegacy/fluentd:1.19.0-debian-12-r2
 ARG ES_VERSION=7.13.3
 USER 0
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 # Custom Fluentd image for fino, shipping logs to Sematext.
 # Base: upstream, maintained fluent/fluentd (we left the now-frozen
-# bitnamilegacy/fluentd base). apt-get upgrade + the gem refresh below pull the
-# latest Debian and Ruby stdlib CVE fixes at build time, so a plain rebuild
-# (re-tag) picks up security patches without a base bump.
-FROM fluent/fluentd:v1.19-debian-2
+# bitnamilegacy/fluentd base). Pinned by digest for reproducibility; apt-get
+# upgrade still pulls the latest Debian CVE fixes at build time. Bump the digest
+# (and the gem pins below) by rebuilding against a newer base periodically.
+FROM fluent/fluentd:v1.19-debian-2@sha256:2d24ed0601b054e88df77a850ed9bc5a35fab3a58a6a7d7aa70258ee51037050
+
+LABEL org.opencontainers.image.source="https://github.com/fino-digital/fluentd" \
+      org.opencontainers.image.description="fino custom Fluentd (Sematext output) on upstream fluent/fluentd" \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 # elasticsearch (client) and fluent-plugin-elasticsearch are intentionally
 # pinned: these versions are known to talk to the Sematext logsene receiver
@@ -15,22 +19,30 @@ ARG ES_VERSION=7.13.3
 USER 0
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# All gems are pinned for reproducible builds. The bundled Ruby gems below are
+# pinned to their current CVE-fixed releases; bump them on a rebuild when new
+# fixes land. net-imap is removed outright: nothing in our pipeline does IMAP,
+# and it is a recurring CVE source, so dropping it shrinks the attack surface.
 RUN apt-get update \
   && apt-get upgrade -y --no-install-recommends \
   && apt-get install -y --no-install-recommends build-essential libffi-dev libssl-dev \
-  && gem update erb net-imap rdoc rexml cgi \
+  && gem install erb -v 6.0.4 \
+  && gem install rdoc -v 7.2.0 \
+  && gem install rexml -v 3.4.4 \
+  && gem install cgi -v 0.5.1 \
   && gem install elasticsearch -v ${ES_VERSION} \
   && gem install elasticsearch-api -v ${ES_VERSION} \
   && gem install elasticsearch-transport -v ${ES_VERSION} \
   && gem install elasticsearch-xpack -v ${ES_VERSION} \
   && gem install fluent-plugin-elasticsearch -v 4.3.3 \
-  && gem install fluent-plugin-s3 \
-  && gem install fluent-plugin-rewrite-tag-filter \
-  && gem install fluent-plugin-record-modifier \
-  && gem install fluent-plugin-concat \
-  && gem install fluent-plugin-kubernetes_metadata_filter \
-  && gem install fluent-plugin-prometheus \
-  && gem install fluent-plugin-anonymizer \
+  && gem install fluent-plugin-s3 -v 1.8.4 \
+  && gem install fluent-plugin-rewrite-tag-filter -v 2.4.0 \
+  && gem install fluent-plugin-record-modifier -v 2.2.1 \
+  && gem install fluent-plugin-concat -v 2.6.2 \
+  && gem install fluent-plugin-kubernetes_metadata_filter -v 3.8.0 \
+  && gem install fluent-plugin-prometheus -v 2.2.2 \
+  && gem install fluent-plugin-anonymizer -v 1.0.0 \
+  && { gem uninstall net-imap --all --executables --ignore-dependencies --force || true; } \
   && apt-get purge -y --auto-remove build-essential libffi-dev libssl-dev \
   && rm -rf /var/lib/apt/lists/* /usr/local/bundle/cache/*
 
@@ -45,6 +57,8 @@ RUN mkdir -p /opt/bitnami/fluentd/conf /opt/bitnami/fluentd/logs/buffers \
   && ln -s /opt/bitnami/fluentd/conf /fluentd/etc \
   && chown -R fluent:fluent /opt/bitnami /fluentd
 
-RUN gem list | grep -E 'elastic|fluent-plugin'
+# Show the installed plugin/es gems and confirm net-imap is gone.
+RUN gem list | grep -E 'elastic|fluent-plugin' \
+  && { gem list | grep -qi '^net-imap ' && echo "WARNING: net-imap still present" || echo "net-imap removed"; }
 
 USER 1001

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ USER 0
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
+  && apt-get upgrade -y --no-install-recommends \
   && apt-get install -y --no-install-recommends build-essential libffi-dev libssl-dev \
   && gem install elasticsearch -v ${ES_VERSION} \
   && gem install elasticsearch-api -v ${ES_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,17 +19,11 @@ ARG ES_VERSION=7.13.3
 USER 0
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# All gems are pinned for reproducible builds. The bundled Ruby gems below are
-# pinned to their current CVE-fixed releases; bump them on a rebuild when new
-# fixes land. net-imap is removed outright: nothing in our pipeline does IMAP,
-# and it is a recurring CVE source, so dropping it shrinks the attack surface.
+# All gems are pinned for reproducible builds.
 RUN apt-get update \
   && apt-get upgrade -y --no-install-recommends \
   && apt-get install -y --no-install-recommends build-essential libffi-dev libssl-dev \
   && gem install erb -v 6.0.4 \
-  && gem install rdoc -v 7.2.0 \
-  && gem install rexml -v 3.4.4 \
-  && gem install cgi -v 0.5.1 \
   && gem install elasticsearch -v ${ES_VERSION} \
   && gem install elasticsearch-api -v ${ES_VERSION} \
   && gem install elasticsearch-transport -v ${ES_VERSION} \
@@ -42,9 +36,20 @@ RUN apt-get update \
   && gem install fluent-plugin-kubernetes_metadata_filter -v 3.8.0 \
   && gem install fluent-plugin-prometheus -v 2.2.2 \
   && gem install fluent-plugin-anonymizer -v 1.0.0 \
-  && { gem uninstall net-imap --all --executables --ignore-dependencies --force || true; } \
   && apt-get purge -y --auto-remove build-essential libffi-dev libssl-dev \
   && rm -rf /var/lib/apt/lists/* /usr/local/bundle/cache/*
+
+# erb and net-imap are Ruby *default* gems baked into the base: gem install /
+# gem uninstall leaves the original default gemspec on disk, so scanners (and
+# Ruby) still see the vulnerable version. Drop the default specs explicitly.
+# - erb: keep it (fluentd needs it) but force the installed, CVE-fixed 6.0.4 by
+#   removing the vulnerable default gemspec.
+# - net-imap: remove it entirely (default gemspec + lib). Nothing in our pipeline
+#   does IMAP, and it is a recurring CVE source, so dropping it shrinks surface.
+RUN DEFAULT_SPECS="$(ruby -e 'print Gem.default_specifications_dir')" \
+  && RUBYLIB_DIR="$(ruby -e 'print RbConfig::CONFIG["rubylibdir"]')" \
+  && rm -f "$DEFAULT_SPECS"/erb-*.gemspec "$DEFAULT_SPECS"/net-imap-*.gemspec \
+  && rm -rf "$RUBYLIB_DIR"/net/imap.rb "$RUBYLIB_DIR"/net/imap
 
 # Keep the /opt/bitnami directory layout so this image is a drop-in for the
 # deployment that replaced the Bitnami chart: the vendored manifests still
@@ -57,8 +62,11 @@ RUN mkdir -p /opt/bitnami/fluentd/conf /opt/bitnami/fluentd/logs/buffers \
   && ln -s /opt/bitnami/fluentd/conf /fluentd/etc \
   && chown -R fluent:fluent /opt/bitnami /fluentd
 
-# Show the installed plugin/es gems and confirm net-imap is gone.
+# Show the installed plugin/es gems, confirm the fixed erb still loads, and that
+# net-imap is gone (fail the build if it lingers).
 RUN gem list | grep -E 'elastic|fluent-plugin' \
-  && { gem list | grep -qi '^net-imap ' && echo "WARNING: net-imap still present" || echo "net-imap removed"; }
+  && ruby -e "require 'erb'; puts 'erb ' + ERB::VERSION" \
+  && { gem list -e net-imap | grep -qi '^net-imap ' && { echo "ERROR: net-imap still present"; exit 1; } || echo "net-imap removed"; } \
+  && { ruby -e "require 'net/imap'" 2>/dev/null && { echo "ERROR: net/imap still loadable"; exit 1; } || echo "net/imap not loadable"; }
 
 USER 1001

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,9 @@ RUN apt-get update \
 #   does IMAP, and it is a recurring CVE source, so dropping it shrinks surface.
 RUN DEFAULT_SPECS="$(ruby -e 'print Gem.default_specifications_dir')" \
   && RUBYLIB_DIR="$(ruby -e 'print RbConfig::CONFIG["rubylibdir"]')" \
-  && rm -f "$DEFAULT_SPECS"/erb-*.gemspec "$DEFAULT_SPECS"/net-imap-*.gemspec \
+  && rm -f "$DEFAULT_SPECS"/erb-*.gemspec \
+  && { gem uninstall -aIx --force net-imap 2>/dev/null || true; } \
+  && for d in $(ruby -e 'puts Gem::Specification.dirs'); do rm -f "$d"/net-imap-*.gemspec; done \
   && rm -rf "$RUBYLIB_DIR"/net/imap.rb "$RUBYLIB_DIR"/net/imap
 
 # Keep the /opt/bitnami directory layout so this image is a drop-in for the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,35 @@
-FROM docker.io/bitnamilegacy/fluentd:1.19.0-debian-12-r2
+FROM fluent/fluentd:v1.19-debian-2
+
 ARG ES_VERSION=7.13.3
+
 USER 0
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN gem update --system 3.5.14 \
-  && gem uninstall elasticsearch --force -x \
-  && gem uninstall elasticsearch-api --force -x\
-  && gem uninstall elastic-transport --force -x \
-  && gem uninstall elasticsearch-xpack --force -x \ 
-  && gem uninstall fluent-plugin-elasticsearch --force -x \
-  && gem uninstall json --force -x
-RUN gem install elasticsearch -v ${ES_VERSION} \
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential libffi-dev libssl-dev \
+  && gem install elasticsearch -v ${ES_VERSION} \
   && gem install elasticsearch-api -v ${ES_VERSION} \
   && gem install elasticsearch-transport -v ${ES_VERSION} \
   && gem install elasticsearch-xpack -v ${ES_VERSION} \
-  && gem install fluent-plugin-anonymizer -v 1.0.0 \
   && gem install fluent-plugin-elasticsearch -v 4.3.3 \
+  && gem install fluent-plugin-s3 \
   && gem install fluent-plugin-rewrite-tag-filter \
-  && gem install fluent-plugin-multi-format-parser
-RUN gem list | grep -E 'elastic|json'
+  && gem install fluent-plugin-record-modifier \
+  && gem install fluent-plugin-concat \
+  && gem install fluent-plugin-kubernetes_metadata_filter \
+  && gem install fluent-plugin-prometheus \
+  && gem install fluent-plugin-anonymizer \
+  && apt-get purge -y --auto-remove build-essential libffi-dev libssl-dev \
+  && rm -rf /var/lib/apt/lists/* /usr/local/bundle/cache/*
+
+# Match the directory layout the Bitnami Fluentd Helm chart mounts into,
+# and point the upstream entrypoint's default config dir at it so
+# `--config /fluentd/etc/${FLUENTD_CONF}` resolves into the mounted configmap.
+RUN mkdir -p /opt/bitnami/fluentd/conf /opt/bitnami/fluentd/logs/buffers \
+  && rm -rf /fluentd/etc \
+  && ln -s /opt/bitnami/fluentd/conf /fluentd/etc \
+  && chown -R fluent:fluent /opt/bitnami /fluentd
+
+RUN gem list | grep -E 'elastic|fluent-plugin'
+
 USER 1001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
+# Custom Fluentd image for fino, shipping logs to Sematext.
+# Base: upstream, maintained fluent/fluentd (we left the now-frozen
+# bitnamilegacy/fluentd base). apt-get upgrade + the gem refresh below pull the
+# latest Debian and Ruby stdlib CVE fixes at build time, so a plain rebuild
+# (re-tag) picks up security patches without a base bump.
 FROM fluent/fluentd:v1.19-debian-2
 
+# elasticsearch (client) and fluent-plugin-elasticsearch are intentionally
+# pinned: these versions are known to talk to the Sematext logsene receiver
+# correctly. Do NOT bump without validating ingestion against Sematext first
+# (newer fluent-plugin-elasticsearch / ES 8.x clients change the bulk API
+# handshake). If a vuln scan flags them, validate a bump on a test index.
 ARG ES_VERSION=7.13.3
 
 USER 0
@@ -24,9 +34,12 @@ RUN apt-get update \
   && apt-get purge -y --auto-remove build-essential libffi-dev libssl-dev \
   && rm -rf /var/lib/apt/lists/* /usr/local/bundle/cache/*
 
-# Match the directory layout the Bitnami Fluentd Helm chart mounts into,
-# and point the upstream entrypoint's default config dir at it so
-# `--config /fluentd/etc/${FLUENTD_CONF}` resolves into the mounted configmap.
+# Keep the /opt/bitnami directory layout so this image is a drop-in for the
+# deployment that replaced the Bitnami chart: the vendored manifests still
+# mount the config at /opt/bitnami/fluentd/conf and write buffers under
+# /opt/bitnami/fluentd/logs/buffers. The symlink makes the upstream entrypoint's
+# `fluentd -c /fluentd/etc/${FLUENTD_CONF}` resolve into the mounted configmap.
+# (Moving to a plain /fluentd layout means changing those mounts in lockstep.)
 RUN mkdir -p /opt/bitnami/fluentd/conf /opt/bitnami/fluentd/logs/buffers \
   && rm -rf /fluentd/etc \
   && ln -s /opt/bitnami/fluentd/conf /fluentd/etc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,8 @@ RUN mkdir -p /opt/bitnami/fluentd/conf /opt/bitnami/fluentd/logs/buffers \
 # Show the installed plugin/es gems, confirm the fixed erb still loads, and that
 # net-imap is gone (fail the build if it lingers).
 RUN gem list | grep -E 'elastic|fluent-plugin' \
-  && ruby -e "require 'erb'; puts 'erb ' + ERB::VERSION" \
+  && gem list -e erb \
+  && ruby -e "require 'erb'; ERB.new('ok')" \
   && { gem list -e net-imap | grep -qi '^net-imap ' && { echo "ERROR: net-imap still present"; exit 1; } || echo "net-imap removed"; } \
   && { ruby -e "require 'net/imap'" 2>/dev/null && { echo "ERROR: net/imap still loadable"; exit 1; } || echo "net/imap not loadable"; }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update \
   && apt-get upgrade -y --no-install-recommends \
   && apt-get install -y --no-install-recommends build-essential libffi-dev libssl-dev \
+  && gem update erb net-imap rdoc rexml cgi \
   && gem install elasticsearch -v ${ES_VERSION} \
   && gem install elasticsearch-api -v ${ES_VERSION} \
   && gem install elasticsearch-transport -v ${ES_VERSION} \

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ elasticsearch output, OTC S3, kubernetes metadata, anonymizer, etc.).
 
 ## Base image
 
-Built `FROM fluent/fluentd:v1.19-debian-2` (upstream, maintained). We moved off
-`bitnamilegacy/fluentd`, which is frozen and no longer gets CVE fixes. Each
-build runs `apt-get upgrade` (Debian CVEs) and refreshes the Ruby stdlib gems
-that tend to get CVEs (`erb net-imap rdoc rexml cgi`), so re-tagging the image
-picks up security patches without a base bump.
+Built `FROM fluent/fluentd:v1.19-debian-2`, pinned by digest (upstream,
+maintained). We moved off `bitnamilegacy/fluentd`, which is frozen and no longer
+gets CVE fixes. Each build still runs `apt-get upgrade` for Debian CVEs. All
+gems are pinned for reproducible builds; the CVE-prone bundled Ruby gems (`erb`,
+`rdoc`, `rexml`, `cgi`) are pinned to their current fixed releases, and
+`net-imap` is removed (nothing here uses IMAP, and it is a recurring CVE
+source). Bump the base digest and the gem pins on a periodic rebuild.
 
 ## Pinned elasticsearch gems
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
 # Fluentd
 
-Update dependencies of image bitnami/fluentd to work correctly with sematext as backend.
+Custom Fluentd image for fino, shipping logs to Sematext. It is the upstream
+`fluent/fluentd` image plus the gems needed for our pipeline (Sematext via the
+elasticsearch output, OTC S3, kubernetes metadata, anonymizer, etc.).
+
+## Base image
+
+Built `FROM fluent/fluentd:v1.19-debian-2` (upstream, maintained). We moved off
+`bitnamilegacy/fluentd`, which is frozen and no longer gets CVE fixes. Each
+build runs `apt-get upgrade` (Debian CVEs) and refreshes the Ruby stdlib gems
+that tend to get CVEs (`erb net-imap rdoc rexml cgi`), so re-tagging the image
+picks up security patches without a base bump.
+
+## Pinned elasticsearch gems
+
+`elasticsearch` / `elasticsearch-api` / `elasticsearch-transport` /
+`elasticsearch-xpack` are pinned to 7.13.3 and `fluent-plugin-elasticsearch` to
+4.3.3. These talk to the Sematext logsene receiver correctly; newer clients
+(ES 8.x, fluent-plugin-elasticsearch 5.x) change the bulk-API handshake. Do not
+bump without validating ingestion against Sematext first. If a vuln scan flags
+them, validate the bump against a throwaway Sematext index before releasing.
+
+## Layout
+
+The image keeps the `/opt/bitnami/fluentd` layout (config at
+`/opt/bitnami/fluentd/conf`, buffers under `/opt/bitnami/fluentd/logs/buffers`)
+so it is a drop-in for the provisioning manifests that replaced the Bitnami
+chart. Switching to a plain `/fluentd` layout requires changing those mounts in
+the manifests at the same time.
+
+## Releasing
+
+`.github/workflows/release.yaml` builds and pushes `ghcr.io/fino-digital/fluentd:<tag>`
+on any git tag push. To release: tag the commit (e.g. `git tag v1.19.2 && git
+push origin v1.19.2`), then bump the image tag in the provisioning repo
+(`00_base/infrastructure/fluentd/_manifests/*.yaml`, and the Bitnami HelmRelease
+override for any env still on the chart). Roll out dev -> test -> prod.


### PR DESCRIPTION
Rebuilds the custom Fluentd image on a maintained, hardened base. The deployed
v1.19.0 image is still built FROM the frozen docker.io/bitnamilegacy/fluentd
(no more CVE fixes); this moves to upstream fluent/fluentd and cuts HIGH+CRITICAL
vulns from ~477 to 10 (all remaining are Debian packages with no upstream fix).

Changes:
* Base: FROM fluent/fluentd:v1.19-debian-2, pinned by digest. apt-get upgrade
  still runs at build for Debian CVEs.
* All gems pinned for reproducible builds (the fluent-plugin gems were unpinned).
  elasticsearch 7.13.3 / fluent-plugin-elasticsearch 4.3.3 stay pinned for
  Sematext logsene compatibility (documented inline).
* Removed net-imap and forced the CVE-fixed erb. These are Ruby default gems, so
  gem install/uninstall does not change what scanners see -- the vulnerable
  default gemspecs are deleted explicitly. Build fails if net-imap lingers.
* OCI image labels (source/description/licenses).
* CI: bumped actions (checkout v4, login v3, buildx v3, build-push v6), added a
  least-privilege permissions block and a report-only Trivy HIGH/CRITICAL scan.

Keeps the /opt/bitnami layout so the image is a drop-in for the provisioning
manifests that replaced the Bitnami chart. Validated in dev as the v1.19.2-beta*
tags; released as v1.19.2-fino-20260619.1.